### PR TITLE
Fix: Members social style allignment

### DIFF
--- a/_pages/about/members.md
+++ b/_pages/about/members.md
@@ -28,7 +28,7 @@ You can also make a pull request directly from Github to this page as proof.
 ## {{member.name}}{% if member.nickname %} ({{ member.nickname }}){% endif %}
 
  {% if member.title %}{{ member.title }}{% endif %} {% if member.workplace %} @ {{ member.workplace }}{% endif %}
-<ul class="author__urls social-icons" style="display: flex;">
+<ul class="author__urls social-icons member__socials">
   {% for social in member.socials %}
   
   {% case social[0] %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -22,3 +22,8 @@ html {
       font-size: 20px; // change to whatever
     }
   }
+
+// Custom CSS due to CSP preventing inline style on members page.
+.member__socials { 
+  display: flex;
+}


### PR DESCRIPTION
Fixing alignment of the new members layout. I wasn't aware about the CSP in-place, therefore working fine in local development.
Bit "lazy" to add into main.scss, but was already there ;-) 

For local testing, adding the following to Jekyll config mimics the production site. (there might be some deviance in regards to production but this was able to re-produce same error behavior as in production)
````yaml
webrick:
  headers:
    Content-Security-Policy: "frame-ancestors 'self';block-all-mixed-content;default-src 'self';script-src 'self' 'report-sample' 'unsafe-inline' https://cdn.jsdelivr.net https://m.youtube.com https://static.cloudflareinsights.com https://www.youtube.com;style-src 'self' 'sha256-7rEqSAuuB6CE8tSDj++HkI9QqisBgGTO8poo8RB/bfE=' 'sha256-anQSeQoEnQnBulZOQkDOFf+e6xBIGmqh7M8YFT992co=' 'report-sample' 'unsafe-inline' cdn.jsdelivr.net;object-src 'none';frame-src 'self' *.youtube.com www.youtube-nocookie.com;child-src 'self' www.youtube.com;img-src 'self' data: *.ytimg.com *.youtube.com cdn.jsdelivr.net github.githubassets.com;font-src 'self' cdn.jsdelivr.net;connect-src 'self' cloudflareinsights.com cdn.jsdelivr.net;manifest-src 'self';base-uri 'self';form-action 'self';media-src 'self';prefetch-src 'self';worker-src 'self';"

