### PR TITLE
Fix: Match Github Pages dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "github-pages", group: :jekyll_plugins
+gem "github-pages", "~> 228", group: :jekyll_plugins
 
 gem "tzinfo-data"
 gem "wdm", "~> 0.1.0" if Gem.win_platform?

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,8 @@
 source "https://rubygems.org"
 
+gem "jekyll"
 gem "github-pages", "~> 228", group: :jekyll_plugins
 
-gem "tzinfo-data"
-gem "wdm", "~> 0.1.0" if Gem.win_platform?
-
-# If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-paginate"
   gem "jekyll-sitemap"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,8 +276,6 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2023.4)
-      tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.9.1)
@@ -288,7 +286,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages
+  github-pages (~> 228)
+  jekyll
   jekyll-algolia
   jekyll-feed
   jekyll-gist
@@ -296,7 +295,6 @@ DEPENDENCIES
   jekyll-paginate
   jekyll-sitemap
   jemoji
-  tzinfo-data
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
To match github pages I've changed the Gemfile and updated lock.
https://pages.github.com/versions/