### PR TITLE
Revert "Bump nokogiri from 1.15.5 to 1.16.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,7 +241,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.20.0)
     mutex_m (0.2.0)
-    nokogiri (1.16.2)
+    nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     octokit (4.25.1)


### PR DESCRIPTION
Reverts VSecDK/vsec.dk#34